### PR TITLE
SMSV-26 profile page type error

### DIFF
--- a/frontend/templates/profile.html
+++ b/frontend/templates/profile.html
@@ -13,7 +13,7 @@
     <div class="profile-section">
         <h2>Avatar</h2>
         <p>View, edit, or delete your avatar.</p>
-        {% if 'avatarFilename' in student and student['avatarFilename'] != none %}
+        {% if student['avatarFilename'] != none %}
             <img src="/static/images/avatars/{{ student['avatarFilename'] }}">
             <form action="/student/avatar" method="POST" enctype="multipart/form-data">
                 <input name="file" type="file">


### PR DESCRIPTION
The profile page was giving a TypeError because the student object is not iterable. Fixed by removing a check to see if a key was in the student object.

Credit goes to Ryan for finding this solution.